### PR TITLE
Reproduce attribute issue

### DIFF
--- a/test/Mono.Linker.Tests.Cases/TypeForwarding/AttributeEnumArgumentForwarded.cs
+++ b/test/Mono.Linker.Tests.Cases/TypeForwarding/AttributeEnumArgumentForwarded.cs
@@ -1,0 +1,32 @@
+using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.TypeForwarding.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.TypeForwarding
+{
+	// Actions:
+	// link - This assembly, Forwarder.dll and Implementation.dll
+	[SetupLinkerDefaultAction ("link")]
+
+	[SetupCompileBefore ("Forwarder.dll", new[] { "Dependencies/MyEnum.cs" }, defines: new[] { "INCLUDE_REFERENCE_IMPL" })]
+	[SetupCompileBefore ("Attribute.dll", new[] { "Dependencies/AttributeWithEnumArgument.cs" }, references: new[] { "Forwarder.dll" })]
+
+	// After compiling the test case we then replace the reference impl with implementation + type forwarder
+	[SetupCompileAfter ("Implementation.dll", new[] { "Dependencies/MyEnum.cs" })]
+	[SetupCompileAfter ("Forwarder.dll", new[] { "Dependencies/MyEnumForwarder.cs" }, references: new[] { "Implementation.dll" })]
+
+	[KeptTypeInAssembly ("Forwarder.dll", typeof (UsedToReferenceForwarderAssembly))]
+	[KeptTypeInAssembly ("Implementation.dll", "Mono.Linker.Tests.Cases.TypeForwarding.Dependencies.MyEnum")]
+	class AttributeEnumArgumentForwarded
+	{
+		static void Main ()
+		{
+            // For the issue to repro, the forwarder assembly must be processed by SweepStep before
+            // the attribute. Referencing it first in the test does this, even though it's not really
+            // a guarantee, since the assembly action dictionary doesn't guarantee order.
+            var _ = typeof (UsedToReferenceForwarderAssembly);
+            var _2 = typeof (AttributedType);
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/TypeForwarding/Dependencies/AttributeWithEnumArgument.cs
+++ b/test/Mono.Linker.Tests.Cases/TypeForwarding/Dependencies/AttributeWithEnumArgument.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace Mono.Linker.Tests.Cases.TypeForwarding.Dependencies
+{
+    public class AttributeWithEnumArgumentAttribute : Attribute
+    {
+    	public AttributeWithEnumArgumentAttribute (MyEnum arg)
+    	{
+    	}
+    }
+
+   	[AttributeWithEnumArgument (MyEnum.A)]
+    public class AttributedType
+    {
+    }
+}

--- a/test/Mono.Linker.Tests.Cases/TypeForwarding/Dependencies/MyEnum.cs
+++ b/test/Mono.Linker.Tests.Cases/TypeForwarding/Dependencies/MyEnum.cs
@@ -1,0 +1,13 @@
+namespace Mono.Linker.Tests.Cases.TypeForwarding.Dependencies
+{
+    public enum MyEnum
+    {
+        A,
+        B,
+        C
+    }
+
+    public class UsedToReferenceForwarderAssembly
+    {
+    }
+}

--- a/test/Mono.Linker.Tests.Cases/TypeForwarding/Dependencies/MyEnumForwarder.cs
+++ b/test/Mono.Linker.Tests.Cases/TypeForwarding/Dependencies/MyEnumForwarder.cs
@@ -1,0 +1,11 @@
+using System.Runtime.CompilerServices;
+using Mono.Linker.Tests.Cases.TypeForwarding.Dependencies;
+
+[assembly: TypeForwardedTo (typeof (MyEnum))]
+
+namespace Mono.Linker.Tests.Cases.TypeForwarding.Dependencies
+{
+    public class UsedToReferenceForwarderAssembly
+    {
+    }
+}


### PR DESCRIPTION
Looks like the issue isn't what I thought it was. The problem actually happens for an attribute enum arg in a "link" assembly, where the enum typeref points to a forwarder. In this case we don't want to keep the forwarder.

The problem is that SweepStep removes the (unused) enum forwarder before it tries to fix the scope of the attribute arg, so fixing the scope fails (Resolve returns null [here](https://github.com/mono/linker/blob/main/src/linker/Linker.Steps/SweepStep.cs#L687), and the scope isn't updated). Then when we go to output the assembly, cecil complains about the unresolved scope.

I think the proper fix is to update scopes in SweepStep for all assemblies, before removing any type forwarders. Before your changes, this worked because the forwarder would have been marked (by the logic in MarkStep that marks forwarders pointing to any marked type) - though even before your change it might be possible to repro this with "copyused" assemblies (I will continue to try).