### PR TITLE
Reproduce attribute issue for copyused assemblies

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -12,9 +12,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>1bfe91238cb39b9620b878b8f1bf0c789324b4cd</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.IL" Version="6.0.0-preview.4.21178.6">
+    <Dependency Name="Microsoft.NET.Sdk.IL" Version="6.0.0-preview.4.21205.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>102d1e856c7e0e553abeec937783da5debed73ad</Sha>
+      <Sha>95201492e7665c7f21faf42e9d544396ff714497</Sha>
       <!--
       This would introduce a cyclic dependency, so it's explictly not enabled for now
       <SourceBuild RepoName="runtime" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -3,14 +3,14 @@
   <ProductDependencies>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="6.0.0-beta.21176.2">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="6.0.0-beta.21203.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>9a72efb067b74bb9147f9413ade6173b568ea1af</Sha>
+      <Sha>1bfe91238cb39b9620b878b8f1bf0c789324b4cd</Sha>
       <SourceBuild RepoName="arcade" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.ApiCompat" Version="6.0.0-beta.21176.2">
+    <Dependency Name="Microsoft.DotNet.ApiCompat" Version="6.0.0-beta.21203.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>9a72efb067b74bb9147f9413ade6173b568ea1af</Sha>
+      <Sha>1bfe91238cb39b9620b878b8f1bf0c789324b4cd</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Sdk.IL" Version="6.0.0-preview.4.21178.6">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -20,7 +20,7 @@
     <SystemReflectionMetadataVersion>5.0.0</SystemReflectionMetadataVersion>
     <MicrosoftBuildFrameworkVersion>16.10.0-preview-21112-04</MicrosoftBuildFrameworkVersion>
     <MicrosoftBuildUtilitiesCoreVersion>16.10.0-preview-21112-04</MicrosoftBuildUtilitiesCoreVersion>
-    <MicrosoftDotNetApiCompatVersion>6.0.0-beta.21176.2</MicrosoftDotNetApiCompatVersion>
+    <MicrosoftDotNetApiCompatVersion>6.0.0-beta.21203.1</MicrosoftDotNetApiCompatVersion>
     <MicrosoftDotNetCodeAnalysisVersion>6.0.0-beta.21105.12</MicrosoftDotNetCodeAnalysisVersion>
     <MicrosoftCodeAnalysisCSharpCodeStyleVersion>3.9.0</MicrosoftCodeAnalysisCSharpCodeStyleVersion>
     <MicrosoftCodeAnalysisCSharpWorkspacesVersion>3.9.0</MicrosoftCodeAnalysisCSharpWorkspacesVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -13,7 +13,7 @@
   <PropertyGroup>
     <UsingToolMicrosoftNetCompilers>true</UsingToolMicrosoftNetCompilers>
     <!-- ilasm -->
-    <MicrosoftNETSdkILPackageVersion>6.0.0-preview.4.21178.6</MicrosoftNETSdkILPackageVersion>
+    <MicrosoftNETSdkILPackageVersion>6.0.0-preview.4.21205.1</MicrosoftNETSdkILPackageVersion>
     <!-- see https://github.com/dotnet/runtime/issues/1338 -->
     <MicrosoftNETCoreILAsmVersion>$(MicrosoftNETSdkILPackageVersion)</MicrosoftNETCoreILAsmVersion>
     <!-- These should match the SDK version at https://github.com/dotnet/sdk/blob/master/eng/Versions.props -->

--- a/eng/common/performance/android_scenarios.proj
+++ b/eng/common/performance/android_scenarios.proj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.DotNet.Helix.Sdk" DefaultTargets="Test">
+  <PropertyGroup Condition="'$(AGENT_OS)' != 'Windows_NT'">
+    <Python>python3</Python>
+    <HelixPreCommands>$(HelixPreCommands);chmod +x $HELIX_WORKITEM_PAYLOAD/SOD/SizeOnDisk</HelixPreCommands>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <HelixCorrelationPayload Include="$(CorrelationPayloadDirectory)">
+      <PayloadDirectory>%(Identity)</PayloadDirectory>
+    </HelixCorrelationPayload>
+  </ItemGroup>
+
+  <PropertyGroup Condition="'$(AGENT_OS)' == 'Windows_NT'">
+    <ScenarioDirectory>%HELIX_CORRELATION_PAYLOAD%\performance\src\scenarios\</ScenarioDirectory>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(AGENT_OS)' != 'Windows_NT'">
+    <ScenarioDirectory>$HELIX_CORRELATION_PAYLOAD/performance/src/scenarios/</ScenarioDirectory>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <HelixWorkItem Include="SOD - Android HelloWorld APK Size">
+        <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
+        <PreCommands>cd $(ScenarioDirectory)helloandroid;copy %HELIX_CORRELATION_PAYLOAD%\HelloAndroid.apk .;$(Python) pre.py</PreCommands>
+        <Command>$(Python) test.py sod --scenario-name &quot;%(Identity)&quot;</Command>
+        <PostCommands>$(Python) post.py</PostCommands>
+    </HelixWorkItem>
+    <HelixWorkItem Include="SOD - Android HelloWorld Extracted Size">
+        <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
+        <PreCommands>cd $(ScenarioDirectory)helloandroid;copy %HELIX_CORRELATION_PAYLOAD%\HelloAndroid.apk .;$(Python) pre.py --unzip</PreCommands>
+        <Command>$(Python) test.py sod --scenario-name &quot;%(Identity)&quot;</Command>
+        <PostCommands>$(Python) post.py</PostCommands>
+    </HelixWorkItem>
+  </ItemGroup>
+</Project>

--- a/eng/common/performance/performance-setup.ps1
+++ b/eng/common/performance/performance-setup.ps1
@@ -19,7 +19,8 @@ Param(
     [switch] $Compare,
     [string] $MonoDotnet="",
     [string] $Configurations="CompilationMode=$CompilationMode RunKind=$Kind",
-    [string] $LogicalMachine=""
+    [string] $LogicalMachine="",
+    [switch] $AndroidMono
 )
 
 $RunFromPerformanceRepo = ($Repository -eq "dotnet/performance") -or ($Repository -eq "dotnet-performance")
@@ -41,6 +42,7 @@ if ($Internal) {
         "perftiger" { $Queue = "Windows.10.Amd64.19H1.Tiger.Perf"  }
         "perfowl" { $Queue = "Windows.10.Amd64.20H2.Owl.Perf"  }
         "perfsurf" { $Queue = "Windows.10.Arm64.Perf.Surf"  }
+        "perfpixel4a" { $Queue = "Windows.10.Amd64.Pixel.Perf" }
         Default { $Queue = "Windows.10.Amd64.19H1.Tiger.Perf" }
     }
     $PerfLabArguments = "--upload-to-perflab-container"
@@ -100,6 +102,15 @@ if ($UseCoreRun) {
 if ($UseBaselineCoreRun) {
     $NewBaselineCoreRoot = (Join-Path $PayloadDirectory "Baseline_Core_Root")
     Move-Item -Path $BaselineCoreRootDirectory -Destination $NewBaselineCoreRoot
+}
+
+if ($AndroidMono) {
+    if(!(Test-Path $WorkItemDirectory))
+    {
+        mkdir $WorkItemDirectory
+    }
+    Copy-Item -path "$SourceDirectory\artifacts\bin\AndroidSampleApp\arm64\Release\android-arm64\publish\apk\bin\HelloAndroid.apk" $PayloadDirectory
+    $SetupArguments = $SetupArguments -replace $Architecture, 'arm64'
 }
 
 $DocsDir = (Join-Path $PerformanceDirectory "docs")

--- a/global.json
+++ b/global.json
@@ -8,7 +8,7 @@
     }
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.21176.2",
+    "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.21203.1",
     "Microsoft.FIX-85B6-MERGE-9C38-CONFLICT": "1.0.0",
     "Microsoft.NET.Sdk.IL": "6.0.0-preview.4.21178.6"
   }

--- a/global.json
+++ b/global.json
@@ -10,6 +10,6 @@
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.21203.1",
     "Microsoft.FIX-85B6-MERGE-9C38-CONFLICT": "1.0.0",
-    "Microsoft.NET.Sdk.IL": "6.0.0-preview.4.21178.6"
+    "Microsoft.NET.Sdk.IL": "6.0.0-preview.4.21205.1"
   }
 }

--- a/test/Mono.Linker.Tests.Cases/BCLFeatures/SerializationCtors.cs
+++ b/test/Mono.Linker.Tests.Cases/BCLFeatures/SerializationCtors.cs
@@ -9,6 +9,7 @@ namespace Mono.Linker.Tests.Cases.BCLFeatures
 		public static void Main ()
 		{
 			new C (2);
+			new CustomSerialization ();
 		}
 	}
 
@@ -26,6 +27,39 @@ namespace Mono.Linker.Tests.Cases.BCLFeatures
 		}
 
 		protected C (SerializationInfo info, StreamingContext context)
+		{
+		}
+	}
+
+	[Kept]
+	class CustomSerialization
+	{
+		[Kept]
+		public CustomSerialization ()
+		{
+		}
+
+		[OnSerializing]
+		[KeptAttributeAttribute (typeof (OnSerializingAttribute))]
+		internal void OnSerializingMethod (StreamingContext context)
+		{
+		}
+
+		[OnSerialized]
+		[KeptAttributeAttribute (typeof (OnSerializedAttribute))]
+		internal void OnSerializedMethod (StreamingContext context)
+		{
+		}
+
+		[OnDeserializing]
+		[KeptAttributeAttribute (typeof (OnDeserializingAttribute))]
+		internal void OnDeserializingMethod (StreamingContext context)
+		{
+		}
+
+		[OnDeserialized]
+		[KeptAttributeAttribute (typeof (OnDeserializedAttribute))]
+		internal void OnDeserializedMethod (StreamingContext context)
 		{
 		}
 	}

--- a/test/Mono.Linker.Tests.Cases/Libraries/RootLibrary.cs
+++ b/test/Mono.Linker.Tests.Cases/Libraries/RootLibrary.cs
@@ -83,6 +83,34 @@ namespace Mono.Linker.Tests.Cases.Libraries
 			public void NotUsed ()
 			{
 			}
+
+			[Kept]
+			[OnSerializing]
+			[KeptAttributeAttribute (typeof (OnSerializingAttribute))]
+			private void OnSerializingMethod (StreamingContext context)
+			{
+			}
+
+			[Kept]
+			[OnSerialized]
+			[KeptAttributeAttribute (typeof (OnSerializedAttribute))]
+			private void OnSerializedMethod (StreamingContext context)
+			{
+			}
+
+			[Kept]
+			[OnDeserializing]
+			[KeptAttributeAttribute (typeof (OnDeserializingAttribute))]
+			private void OnDeserializingMethod (StreamingContext context)
+			{
+			}
+
+			[Kept]
+			[OnDeserialized]
+			[KeptAttributeAttribute (typeof (OnDeserializedAttribute))]
+			private void OnDeserializedMethod (StreamingContext context)
+			{
+			}
 		}
 
 		[Kept]

--- a/test/Mono.Linker.Tests.Cases/TypeForwarding/AttributeEnumArgumentForwardedCopyUsed.cs
+++ b/test/Mono.Linker.Tests.Cases/TypeForwarding/AttributeEnumArgumentForwardedCopyUsed.cs
@@ -1,0 +1,39 @@
+using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.TypeForwarding.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.TypeForwarding
+{
+	// Actions:
+	// link - This assembly, Forwarder.dll and Implementation.dll
+	[SetupLinkerDefaultAction ("link")]
+	[SetupLinkerAction ("copyused", "Attribute")]
+
+	[SetupCompileBefore ("Forwarder.dll", new[] { "Dependencies/MyEnum.cs" }, defines: new[] { "INCLUDE_REFERENCE_IMPL" })]
+	[SetupCompileBefore ("Removed.dll", new[] { "Dependencies/UnusedLibrary.cs" })]
+	[SetupCompileBefore ("Attribute.dll", new[] { "Dependencies/AttributeWithEnumArgument.cs" }, references: new[] { "Forwarder.dll", "Removed.dll" })]
+
+	// After compiling the test case we then replace the reference impl with implementation + type forwarder
+	[SetupCompileAfter ("Implementation.dll", new[] { "Dependencies/MyEnum.cs" })]
+	[SetupCompileAfter ("Forwarder.dll", new[] { "Dependencies/MyEnumForwarder.cs" }, references: new[] { "Implementation.dll" })]
+
+	[KeptTypeInAssembly ("Forwarder.dll", typeof (UsedToReferenceForwarderAssembly))]
+	// [KeptTypeInAssembly ("Implementation.dll", "Mono.Linker.Tests.Cases.TypeForwarding.Dependencies.MyEnum")]
+	class AttributeEnumArgumentForwardedCopyUsed
+	{
+		static void Main ()
+		{
+            // For the issue to repro, the forwarder assembly must be processed by SweepStep before
+            // the attribute. Referencing it first in the test does this, even though it's not really
+            // a guarantee, since the assembly action dictionary doesn't guarantee order.
+            var _ = typeof (UsedToReferenceForwarderAssembly);
+			// To repro the issue in a world where we are marking all forwarders that point to marked types,
+			// avoid marking the attributed type (and hence the Enum). Instead, just reference the assembly
+			// with the enum and make it "copyused" to preserve the attributed type anyway (while updating typeref scopes).
+            var _2 = typeof (UsedToReferenceAttributeAssembly);
+			// Additionally, to trigger the behavior the "copyused" assembly has to be changed to "save" in SweepStep.
+			// This happens when it has a reference to a removed assembly.
+		}
+	}
+}

--- a/test/Mono.Linker.Tests.Cases/TypeForwarding/AttributeEnumArgumentForwardedCopyUsed.cs
+++ b/test/Mono.Linker.Tests.Cases/TypeForwarding/AttributeEnumArgumentForwardedCopyUsed.cs
@@ -19,7 +19,7 @@ namespace Mono.Linker.Tests.Cases.TypeForwarding
 	[SetupCompileAfter ("Forwarder.dll", new[] { "Dependencies/MyEnumForwarder.cs" }, references: new[] { "Implementation.dll" })]
 
 	[KeptTypeInAssembly ("Forwarder.dll", typeof (UsedToReferenceForwarderAssembly))]
-	// [KeptTypeInAssembly ("Implementation.dll", "Mono.Linker.Tests.Cases.TypeForwarding.Dependencies.MyEnum")]
+	[KeptTypeInAssembly ("Implementation.dll", "Mono.Linker.Tests.Cases.TypeForwarding.Dependencies.MyEnum")]
 	class AttributeEnumArgumentForwardedCopyUsed
 	{
 		static void Main ()

--- a/test/Mono.Linker.Tests.Cases/TypeForwarding/Dependencies/AttributeWithEnumArgument.cs
+++ b/test/Mono.Linker.Tests.Cases/TypeForwarding/Dependencies/AttributeWithEnumArgument.cs
@@ -1,0 +1,29 @@
+using System;
+using Mono.Linker.Tests.Cases.TypeForwarding.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.TypeForwarding.Dependencies
+{
+    public class AttributeWithEnumArgumentAttribute : Attribute
+    {
+    	public AttributeWithEnumArgumentAttribute (MyEnum arg)
+    	{
+    	}
+    }
+
+   	[AttributeWithEnumArgument (MyEnum.A)]
+    public class AttributedType
+    {
+    }
+
+    public class UsedToReferenceAttributeAssembly
+    {
+    }
+
+    public class UnusedType
+    {
+        public static void ReferenceUnusedAssembly()
+        {
+            var _ = typeof (UnusedLibrary);
+        }
+    }
+}

--- a/test/Mono.Linker.Tests.Cases/TypeForwarding/Dependencies/MyEnum.cs
+++ b/test/Mono.Linker.Tests.Cases/TypeForwarding/Dependencies/MyEnum.cs
@@ -1,0 +1,13 @@
+namespace Mono.Linker.Tests.Cases.TypeForwarding.Dependencies
+{
+    public enum MyEnum
+    {
+        A,
+        B,
+        C
+    }
+
+    public class UsedToReferenceForwarderAssembly
+    {
+    }
+}

--- a/test/Mono.Linker.Tests.Cases/TypeForwarding/Dependencies/MyEnumForwarder.cs
+++ b/test/Mono.Linker.Tests.Cases/TypeForwarding/Dependencies/MyEnumForwarder.cs
@@ -1,0 +1,11 @@
+using System.Runtime.CompilerServices;
+using Mono.Linker.Tests.Cases.TypeForwarding.Dependencies;
+
+[assembly: TypeForwardedTo (typeof (MyEnum))]
+
+namespace Mono.Linker.Tests.Cases.TypeForwarding.Dependencies
+{
+    public class UsedToReferenceForwarderAssembly
+    {
+    }
+}

--- a/test/Mono.Linker.Tests.Cases/TypeForwarding/Dependencies/UnusedLibrary.cs
+++ b/test/Mono.Linker.Tests.Cases/TypeForwarding/Dependencies/UnusedLibrary.cs
@@ -1,0 +1,6 @@
+namespace Mono.Linker.Tests.Cases.TypeForwarding
+{
+    public class UnusedLibrary
+    {
+    }
+}


### PR DESCRIPTION
This shows how to repro the attribute issue before any of your changes @mateoatr.
The test fails because the enum isn't kept, even though it's referenced from the attribute in a copyused assembly. If you debug it you can see that during SweepStep when trying to update the attribute argument scope, cecil throws a resolution exception (but it is caught and just reports that the attribute has no ctor args). We don't really make strong guarantees for copyused assemblies so I am not sure this would be considered a bug - it's more like another instance of the problem where unused typerefs from copyused assemblies can be invalid after linking.